### PR TITLE
Fix touch input and update loadstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Original by [0866's MidiPlayer](https://github.com/richie0866/MidiPlayer), a vir
 Forked from [zoeyluau](https://github.com/zoeyluau/MidiPlayer).
 Run
 ```
-loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/init.lua'))()
+loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/init.lua'))()
 ```
 and go to your executor's workspace path and there should be a new folder named midi created. Place your downloaded MIDI files and instantly use them.
 

--- a/src/Components/App.lua
+++ b/src/Components/App.lua
@@ -10,12 +10,12 @@ local CoreGui = game:GetService("CoreGui")
 
 -- local midiPlayer = script:FindFirstAncestor("MidiPlayer")
 
-local FastDraggable = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/FastDraggable.lua"))()
-local Controller = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Components/Controller.lua"))()
-local Sidebar = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Components/Sidebar.lua"))()
-local Preview = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Components/Preview.lua"))()
+local FastDraggable = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/FastDraggable.lua"))()
+local Controller = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Components/Controller.lua"))()
+local Sidebar = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Components/Sidebar.lua"))()
+local Preview = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Components/Preview.lua"))()
 
-local gui = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Assets/ScreenGui.lua"))()
+local gui = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Assets/ScreenGui.lua"))()
 
 function App:GetGUI()
     return gui

--- a/src/Components/Controller.lua
+++ b/src/Components/Controller.lua
@@ -90,7 +90,7 @@ end
 
 function Controller:_startHidePreviewButton()
     local togglePreview = _G.main.TogglePreview
-    togglePreview.MouseButton1Down:Connect(function()
+    togglePreview.Activated:Connect(function()
         getgenv()._hideSongPreview = (not getgenv()._hideSongPreview)
         if (getgenv()._hideSongPreview) then
             FastTween(togglePreview.Fill, { 0.1 }, { Size = UDim2.new() })
@@ -103,7 +103,7 @@ end
 
 function Controller:_startPlaybackButton()
     local playback = _G.controller.Resume
-    playback.MouseButton1Down:Connect(function()
+    playback.Activated:Connect(function()
         if (not self.CurrentSong) then return end
         if (self.CurrentSong.IsPlaying) then
             self.CurrentSong:Pause()
@@ -146,7 +146,7 @@ function Controller:_startScrubber()
     end)
 
     _G.controller.Scrubber.Hitbox.InputChanged:Connect(function(input)
-        if (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch) then
+        if (input.UserInputType == Enum.UserInputType.MouseMovement or input.UserInputType == Enum.UserInputType.Touch) then
             dragInput = input
         end
     end)
@@ -157,6 +157,16 @@ function Controller:_startScrubber()
                 self.CurrentSong:Pause()
             end
             update(input)
+        end
+    end)
+    
+    -- Additional touch handling for Android compatibility
+    UserInputService.TouchMoved:Connect(function(touch, gameProcessed)
+        if not gameProcessed and dragging and dragInput and touch == dragInput then
+            if (self.CurrentSong) then
+                self.CurrentSong:Pause()
+            end
+            update(touch)
         end
     end)
 

--- a/src/Components/Controller.lua
+++ b/src/Components/Controller.lua
@@ -6,12 +6,12 @@
 
 --local midiPlayer = script:FindFirstAncestor("MidiPlayer")
 
-local Signal = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Util/Signal.lua"))()
-local Date = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Util/Date.lua"))()
-local Thread = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Util/Thread.lua"))()
-local Song = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Song.lua"))()
-local FastTween = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/FastTween.lua"))()
-local Preview = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Components/Preview.lua"))()
+local Signal = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Util/Signal.lua"))()
+local Date = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Util/Date.lua"))()
+local Thread = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Util/Thread.lua"))()
+local Song = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Song.lua"))()
+local FastTween = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/FastTween.lua"))()
+local Preview = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Components/Preview.lua"))()
 
 local Controller = {
     CurrentSong = nil;

--- a/src/Components/Preview.lua
+++ b/src/Components/Preview.lua
@@ -5,7 +5,7 @@
 
 
 local midiPlayer = script:FindFirstAncestor("MidiPlayer")
-local Input = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Input.lua"))()
+local Input = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Input.lua"))()
 
 local Preview = {}
 

--- a/src/Components/Sidebar.lua
+++ b/src/Components/Sidebar.lua
@@ -36,10 +36,13 @@ function Sidebar:CreateElement(filePath)
         element.Selection.Size = UDim2.fromOffset(3, 0)
     end
 
+    element.Activated:Connect(function()
+        Controller:Select(filePath)
+    end)
+
     element.InputBegan:Connect(function(input)
         if (input.UserInputType == Enum.UserInputType.MouseButton1 or input.UserInputType == Enum.UserInputType.Touch) then
             FastTween(element, tweenInfo, { BackgroundTransparency = 0.5 })
-            Controller:Select(filePath)
         end
     end)
 

--- a/src/Components/Sidebar.lua
+++ b/src/Components/Sidebar.lua
@@ -5,9 +5,9 @@
 
 
 local midiPlayer = script:FindFirstAncestor("MidiPlayer")
-local Thread = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Util/Thread.lua"))()
-local Controller = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Components/Controller.lua"))()
-local FastTween = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/FastTween.lua"))()
+local Thread = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Util/Thread.lua"))()
+local Controller = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Components/Controller.lua"))()
+local FastTween = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/FastTween.lua"))()
 
 local Sidebar = {}
 

--- a/src/FastDraggable.lua
+++ b/src/FastDraggable.lua
@@ -37,9 +37,17 @@ local function FastDraggable(gui, handle)
         end
     end)
 
+    -- Handle both UserInputService events and direct input events for better Android compatibility
     UserInputService.InputChanged:Connect(function(input)
         if input == dragInput and dragging then
             update(input)
+        end
+    end)
+    
+    -- Additional touch handling for Android compatibility
+    UserInputService.TouchMoved:Connect(function(touch, gameProcessed)
+        if not gameProcessed and dragging and dragInput and touch == dragInput then
+            update(touch)
         end
     end)
 

--- a/src/Input.lua
+++ b/src/Input.lua
@@ -15,8 +15,8 @@ local NOTE_MAP = "1!2@34$5%6^78*9(0qQwWeErtTyYuiIoOpPasSdDfgGhHjJklLzZxcCvVbBnm"
 local UPPER_MAP = "!@ $%^ *( QWE TY IOP SD GHJ LZ CVB"
 local LOWER_MAP = "1234567890qwertyuiopasdfghjklzxcvbnm"
 
-local Thread = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Util/Thread.lua'))()
-local Maid = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Util/Maid.lua'))()
+local Thread = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Util/Thread.lua'))()
+local Maid = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Util/Maid.lua'))()
 
 local inputMaid = Maid.new()
 

--- a/src/Song.lua
+++ b/src/Song.lua
@@ -7,8 +7,8 @@
 local Song = {}
 Song.__index = Song
 
-local MIDI = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/MIDI.lua'))()
-local Input = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Input.lua'))()
+local MIDI = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/MIDI.lua'))()
+local Input = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Input.lua'))()
 
 local RunService = game:GetService("RunService")
 

--- a/src/Util/Signal.lua
+++ b/src/Util/Signal.lua
@@ -19,7 +19,7 @@
 
 --]]
 
-local Promise = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Util/Promise.lua'))()
+local Promise = loadstring(game:HttpGetAsync('https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Util/Promise.lua'))()
 
 local Connection = {}
 Connection.__index = Connection

--- a/src/init.lua
+++ b/src/init.lua
@@ -2,7 +2,7 @@
 -- 0866
 -- February 13, 2025
 
-local App = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/cjsomook/MidiPlayer/refs/heads/main/src/Components/App.lua"))()
+local App = loadstring(game:HttpGetAsync("https://raw.githubusercontent.com/Saulildo/MidiPlayer/refs/heads/main/src/Components/App.lua"))()
 
 if (not isfolder("midi")) then
     makefolder("midi")


### PR DESCRIPTION
Improve Android compatibility by fixing touch input and updating loadstring URLs to Saulildo's fork.

The original code relied on mouse-specific events (`MouseButton1Down`) and basic touch handling, which prevented song selection and proper UI interaction on Android devices. This PR updates UI event handling to use `Activated` and `TouchMoved` for universal input compatibility, and redirects all external script loads to the specified GitHub fork.